### PR TITLE
Fix cucumber support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.test_queue_stats


### PR DESCRIPTION
In modern cucumber, @features_loader is an array.

Fix:
/.rvm/gems/ruby-2.2.2/gems/test-queue-0.2.13/lib/test_queue/runner/cucumber.rb:26:in `initialize': undefined method`features' for #Array:0x007fbe64afa080 (NoMethodError)

Also I noticed something weird. If I use cucumber-queue on the [page-object](https://github.com/cheezy/page-object) repo, the [test time doubles](https://github.com/cheezy/page-object/issues/298#issuecomment-133977550). I was hoping test-queue would make the cucumbers faster.
