### PR TITLE
Allow running the same tests on multiple browsers in parallel

### DIFF
--- a/lib/test_queue/runner/rspec3.rb
+++ b/lib/test_queue/runner/rspec3.rb
@@ -1,4 +1,31 @@
 module RSpec::Core
+  class World
+    alias_method :rspec_register, :register
+
+    # @api private
+    #
+    # Register an example group.
+    def register(example_group)
+      @caps ||= ::SauceRSpec.config.caps
+
+      examples     = example_group.examples
+      new_examples = []
+      examples.each do |ex|
+        @caps.each do |cap|
+          ex_with_cap = ex.clone
+          ex_with_cap.instance_variable_set(:@id, ex_with_cap.id + cap.to_s)
+          ex_with_cap.instance_eval "def caps; #{cap}; end"
+          new_examples << ex_with_cap
+        end
+      end
+
+      example_group.instance_variable_set(:@examples, new_examples)
+
+      # invoke original register method
+      rspec_register(example_group)
+    end
+  end if defined?(::SauceRSpec)
+
   # RSpec 3.2 introduced:
   unless Configuration.method_defined?(:with_suite_hooks)
     class Configuration


### PR DESCRIPTION
Given:

```

SauceRSpec.config do |config|
  config.caps = [
    Platform.windows_8.firefox.v37,
    Platform.mac_10_11.safari.v8_1
  ]
end

describe 'describe one' do
  it 'it one' do
    puts 'test one'
  end
end

describe 'describe two' do
  it 'it two' do
    puts 'test two'
  end
end
```

The two tests will be run on both platforms.

```
$ rspec-queue spec/
Starting test-queue master (/tmp/test_queue_22016_70137857304740.sock)

==> Summary (1 workers in 0.0211s)

    [ 1]  4 examples, 0 failures         2 suites in 0.0184s      (pid 22018 exit 0)

```

```
test_1_one_spec.rb[1:1]["Windows 2012", "firefox", "37"]
test_2_one_spec.rb[1:1]["Mac 10.11", "safari", "8.1"]
test_3_two_spec.rb[1:1]["Windows 2012", "firefox", "37"]
test_4_two_spec.rb[1:1]["Mac 10.11", "safari", "8.1"]
```
